### PR TITLE
Fix on_focus callback not always being triggered

### DIFF
--- a/src/script_host.cpp
+++ b/src/script_host.cpp
@@ -58,6 +58,7 @@ HRESULT script_host::InitCallbackMap()
 		switch (id)
 		{
 		case callback_id::on_char:
+		case callback_id::on_focus:
 		case callback_id::on_key_down:
 		case callback_id::on_key_up:
 			m_host->m_grabfocus = true;


### PR DESCRIPTION
Currently, the `on_focus` callback will not be triggered when used stand-alone in a panel like this..

```js
function on_focus(is_focused) {
    console.log(is_focused);
}
```

This bug has been present since v2.3.0 when auto-detection of callbacks in a script was added but this was simply omitted from the list. 

For most people, it's worked without problem because other callbacks have been present which has hidden the flaw.